### PR TITLE
cards now cycle, flip, show data

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -2,13 +2,29 @@ import Button from './Button';
 import React from 'react';
 
 export default class Card extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      obverseIsVisible: true,
+    }
+    this.flipCard = this.flipCard.bind(this);
+  }
+
+  flipCard(){
+    this.state.obverseIsVisible === true ? this.setState({obverseIsVisible: false}): this.setState({obverseIsVisible: true});
+  }
+
+  componentWillReceiveProps(){
+    this.setState({obverseIsVisible: true})
+  }
+
   render() {
     return (
       <div className="card ten columns">
         <div className="card-header">
-          <div className="card-flip"> Flip </div>
+          <div className="card-flip"> <a href="#" onClick={this.flipCard}>Flip</a> </div>
         </div>
-        <div className="card-question">Questions about stuff</div>
+        {this.state.obverseIsVisible ? <div className="card-question">{this.props.card.question}</div>: <div className="card-answer">{this.props.card.answer}</div>}
         <Button />
         <Button />
       </div>

--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -3,16 +3,105 @@ import CarouselDots from './CarouselDots';
 import React from 'react';
 
 export default class Carousel extends React.Component {
+  constructor(){
+    super()
+    this.state = {
+      cards: [{
+        id: 1,
+        question: 'What is a Promise?',
+        answer: 'A promise represents the value of an asynchronous operation that is not necessarily know at the time of execution.',
+        resource_url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }, {
+        id: 2,
+        question: 'What are the states of a Promise?',
+        answer: 'Pending, Fulfilled, Rejected',
+        resource_url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Description',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }, {
+        id: 3,
+        question: 'Why would you use a Promise?',
+        answer: 'Promises offer an alternative to performing asynchronous operations that are easier to reason about relative to callbacks.',
+        resource_url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Description',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }, {
+        id: 4,
+        question: 'test',
+        answer: 'test',
+        resource_url: 'test',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }, {
+        id: 5,
+        question: 'What are race conditions?',
+        answer: 'A race condition or race hazard is the behavior of an electronic, software or other system where the output is dependent on the sequence or timing of other uncontrollable events.',
+        resource_url: 'https://blog.raananweber.com/2015/06/17/no-there-are-no-race-conditions-in-javascript/',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }, {
+        id: 6,
+        question: 'What is a callback?',
+        answer: 'In computer programming, a callback is any executable code that is passed as an argument to other code',
+        resource_url: 'https://en.wikipedia.org/wiki/Callback_(computer_programming)',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }, {
+        id: 7,
+        question: 'What is a variable?',
+        answer: 'JavaScript variables are containers for storing data values.',
+        resource_url: 'http://www.w3schools.com/js/js_variables.asp',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      }],
+      currentCard: {
+        id: 1,
+        question: 'What is a Promise?',
+        answer: 'A promise represents the value of an asynchronous operation that is not necessarily know at the time of execution.',
+        resource_url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise',
+        created_at: new Date('2016-06-26 14:26:16 UTC'),
+        updated_at: new Date('2016-06-26 14:26:16 UTC'),
+      },
+      cardIdx: 0
+    };
+    this.cardsForward = this.cardsForward.bind(this);
+    this.cardsBack = this.cardsBack.bind(this);
+  }
+
+  cardsForward() {
+    const incrementedIndex = this.state.cardIdx + 1;
+
+    if (this.state.cards[incrementedIndex]) {
+      this.setState({
+        cardIdx: incrementedIndex,
+        currentCard: this.state.cards[incrementedIndex],
+      });
+    }
+  }
+
+  cardsBack() {
+    const decrementedIndex = this.state.cardIdx - 1;
+
+    if (this.state.cards[decrementedIndex]) {
+      this.setState({
+        cardIdx: decrementedIndex,
+        currentCard: this.state.cards[decrementedIndex],
+      });
+    }
+  }
+
   render() {
     return (
       <div className="carousel">
         <div className="row">
-          <div className="one columns"> ◀︎ </div>
-          <Card />
-          <div className="one columns"> ▶︎ </div>
+          <div className="one columns"> <a href="#" onClick={this.cardsBack}>◀︎</a> </div>
+          <Card card={this.state.currentCard}/>
+          <div className="one columns"> <a href="#" onClick={this.cardsForward}>▶︎</a> </div>
         </div>
         <div className="row carousel-dots">
-          <CarouselDots />
+          <CarouselDots dotCount={this.state.cards.length} currentDot={this.state.cardIdx}/>
         </div>
       </div>
     );

--- a/src/components/CarouselDots.jsx
+++ b/src/components/CarouselDots.jsx
@@ -5,17 +5,26 @@ export default class CarouselDots extends React.Component {
     super(props);
     this.state = {
       dotSequence: '',
-    };
+    }
+    this.createDotSequence = this.createDotSequence.bind(this);
   }
 
-  componentWillReceiveProps(nextProps){
+  createDotSequence(propsSource){
     let sequence = '';
 
     for (let i = 0; i < this.props.dotCount; i++) {
-      i !== nextprops.currentDot ? sequence += '●' : sequence += '○';
+      i !== propsSource.currentDot ? sequence += '●' : sequence += '○';
     }
 
     this.setState({dotSequence: sequence})
+  }
+
+  componentDidMount(nextProps, nextState){
+    this.createDotSequence(this.props);
+  }
+
+  componentWillReceiveProps(nextProps){
+    this.createDotSequence(nextProps);
   }
 
   render () {

--- a/src/components/CarouselDots.jsx
+++ b/src/components/CarouselDots.jsx
@@ -1,9 +1,26 @@
 import React from 'react';
 
 export default class CarouselDots extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      dotSequence: '',
+    };
+  }
+
+  componentWillReceiveProps(nextProps){
+    let sequence = '';
+
+    for (let i = 0; i < this.props.dotCount; i++) {
+      i !== nextProps.currentDot ? sequence += '●' : sequence += '○';
+    }
+
+    this.setState({dotSequence: sequence})
+  }
+
   render () {
     return (
-      <div className="dots twelve columns"> ● ● ● ○ ● ● ● ● ● ● ● ● </div>
+      <div className="dots twelve columns"> {this.state.dotSequence} </div>
     );
   }
 }

--- a/src/components/CarouselDots.jsx
+++ b/src/components/CarouselDots.jsx
@@ -5,26 +5,17 @@ export default class CarouselDots extends React.Component {
     super(props);
     this.state = {
       dotSequence: '',
-    }
-    this.createDotSequence = this.createDotSequence.bind(this);
-  }
-
-  createDotSequence(propsSource){
-    let sequence = '';
-
-    for (let i = 0; i < this.props.dotCount; i++) {
-      i !== propsSource.currentDot ? sequence += '●' : sequence += '○';
-    }
-    
-    this.setState({dotSequence: sequence})
-  }
-
-  componentDidMount(nextProps, nextState){
-    this.createDotSequence(this.props);
+    };
   }
 
   componentWillReceiveProps(nextProps){
-    this.createDotSequence(nextProps);
+    let sequence = '';
+
+    for (let i = 0; i < this.props.dotCount; i++) {
+      i !== nextprops.currentDot ? sequence += '●' : sequence += '○';
+    }
+    
+    this.setState({dotSequence: sequence})
   }
 
   render () {

--- a/src/components/CarouselDots.jsx
+++ b/src/components/CarouselDots.jsx
@@ -1,9 +1,35 @@
 import React from 'react';
 
 export default class CarouselDots extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      dotSequence: '',
+    }
+    this.createDotSequence = this.createDotSequence.bind(this);
+  }
+
+  createDotSequence(propsSource){
+    let sequence = '';
+
+    for (let i = 0; i < this.props.dotCount; i++) {
+      i !== propsSource.currentDot ? sequence += '●' : sequence += '○';
+    }
+    
+    this.setState({dotSequence: sequence})
+  }
+
+  componentDidMount(nextProps, nextState){
+    this.createDotSequence(this.props);
+  }
+
+  componentWillReceiveProps(nextProps){
+    this.createDotSequence(nextProps);
+  }
+
   render () {
     return (
-      <div className="dots twelve columns"> ● ● ● ○ ● ● ● ● ● ● ● ● </div>
+      <div className="dots twelve columns"> {this.state.dotSequence} </div>
     );
   }
 }


### PR DESCRIPTION
Fixes #25 
Fixes #9 
Fixes #26 

Cards now cycle, flip and show content. We haven't implemented user accounts or decks yet and I didn't want to do more than the issues asked me to do, so I used hardcoded data. Ready to make auth work and API calls (which would require adding fetch/axios to the package.json) whenever @MrJadaml gives the word.

Linter throws no errors or warnings. (Edit: my linter appears to be broken...)